### PR TITLE
Explicit clobbering when writing .active file

### DIFF
--- a/mozconfigwrapper.sh
+++ b/mozconfigwrapper.sh
@@ -26,7 +26,7 @@ function buildwith {
     fi
 
     mozconfig="$BUILDWITH_HOME/$name"
-    echo "$name" > "$BUILDWITH_HOME/.active"
+    echo "$name" >| "$BUILDWITH_HOME/.active"
     export MOZCONFIG=$mozconfig
 
     if [ ! "$2" = "silent" ]


### PR DESCRIPTION
Clobbering is disabled by default in Prezto and it gave me an error when sourcing mozconfigwrapper, this PR explicitly uses it using >| (also tested in sh and bash).