### PR TITLE
Quote $BUILDWITH_HOME when passing to |cat|

### DIFF
--- a/mozconfigwrapper.sh
+++ b/mozconfigwrapper.sh
@@ -107,7 +107,7 @@ mozconfigwrapper_setup_tab_completion
 
 if [ -f "$BUILDWITH_HOME/.active" ]
 then
-    active=`cat $BUILDWITH_HOME/.active`
+    active=`cat "$BUILDWITH_HOME/.active"`
     if [ ! $active = "" ]
     then
         buildwith "$active" "silent"


### PR DESCRIPTION
without this, the sourcing of this script from my `.profile` complains about the spaces in my `$HOME` (Hi, Windows...).